### PR TITLE
Refactor supervision tree

### DIFF
--- a/lib/fast_ts/router.ex
+++ b/lib/fast_ts/router.ex
@@ -17,7 +17,7 @@ defmodule FastTS.Router do
       # accumulation (it will be done in macro __before_compile__/1
       @before_compile unquote(__MODULE__)
 
-      FastTS.Router.register_router(__MODULE__)
+      FastTS.Router.Modules.register_router(__MODULE__)
     end
   end
 
@@ -65,11 +65,6 @@ defmodule FastTS.Router do
           def unquote(pipeline_name)(), do: unquote(block)
         end
     end
-  end
-
-  def register_router(module) do
-    Logger.info "Registering Router module: #{inspect module}"
-    FastTS.Router.ModulesRegistry.register(module)
   end
   
 end

--- a/lib/fast_ts/router.ex
+++ b/lib/fast_ts/router.ex
@@ -69,7 +69,7 @@ defmodule FastTS.Router do
 
   def register_router(module) do
     Logger.info "Registering Router module: #{inspect module}"
-    FastTS.Router.Modules.register(module)
+    FastTS.Router.ModulesRegistry.register(module)
   end
   
 end

--- a/lib/fast_ts/router/modules.ex
+++ b/lib/fast_ts/router/modules.ex
@@ -1,0 +1,75 @@
+defmodule FastTS.Router.Modules do
+  use Supervisor
+
+  require Logger
+  alias FastTS.Router
+
+  @moduledoc """
+  Router modules Supervisor
+
+  This module is responsible for starting and supervising the components
+  that manage the Router Modules provided by the end user (See FastTS.Router).
+
+  This includes keeping track of registered Router Modules (Router.ModulesRegistry),
+  loading and starting the Pipelines of declared in the Router Modules (Router.ModulesLoader).
+  """
+
+  def start_link do
+    Supervisor.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def init([]) do
+    child_specs
+    |> supervise(strategy: :one_for_one)
+  end
+
+  defp child_specs do
+    [ 
+      # Modules Registry:
+      # Keeps track of the router modules that were registered
+      worker(Router.ModulesRegistry, []),
+      # Modules Loader:
+      # Transient process that loads the Router Modules
+      worker(Router.ModulesLoader, [], restart: :transient),
+    ]
+  end
+
+  @doc """
+  Register a router module
+  """
+  def register_router(module) do
+    Logger.info "Registering Router module: #{inspect module}"
+    Router.ModulesRegistry.register(module)
+  end
+
+
+  @doc """
+  Retrieves the list of all Router modules
+  """
+  def list do
+    Router.ModulesRegistry.list
+  end
+
+  @doc """
+  Retrieves the list of all pipelines of all router modules.
+
+  ex:
+      [ "Basic pipeline": [stateless: #Function<4.54730107/1 in FastTS.Stream.under/1>,
+          stateless: #Function<6.54730107/1 in FastTS.Stream.stdout/0>],
+        "Second pipeline": [stateful: #Function<5.54730107/2 in FastTS.Stream.rate/1>,
+          stateless: #Function<0.54730107/1 in FastTS.Stream.email/1>,
+          stateless: #Function<6.54730107/1 in FastTS.Stream.stdout/0>]]
+  """
+  def pipelines do
+    Router.ModulesRegistry.list
+    |> Enum.map(&module_streams/1)
+    |> Enum.concat
+  end
+
+  # Apply the `streams` function of the module, which returns
+  # a list of pipeline streams
+  defp module_streams(module) do
+    apply(module, :streams, [])
+  end
+
+end

--- a/lib/fast_ts/router/modules_loader.ex
+++ b/lib/fast_ts/router/modules_loader.ex
@@ -1,0 +1,73 @@
+defmodule FastTS.Router.ModulesLoader do
+  require Logger
+
+  @moduledoc """
+  Component responsible for loading and starting End User provided Router modules
+
+  This is a transient process, that dies after everything is loaded successfully
+  """
+
+  def start_link do
+    Task.start_link(&run/0)
+  end
+
+  defp run do
+    # Load End User provided Router Modules
+    # and Start the pipelines Process
+    # 
+    # Once everything is loaded successfully, the process ends.
+
+    load_modules
+    start_pipelines
+  end
+
+  defp load_modules do
+    get_route_dir
+    |> list_route_files
+    |> check_route_files
+    |> load_route_files
+  end
+
+  defp start_pipelines do
+    FastTS.Router.Modules.pipelines
+    |> Enum.map(&start_pipeline/1)
+  end
+
+  defp start_pipeline({name, pipeline}) do
+    FastTS.Supervisor.start_pipeline!(name, pipeline)
+  end
+
+  defp get_route_dir do
+    # Try from FTS_ROUTE_DIR env, fallback to config file
+    System.get_env("FTS_ROUTE_DIR") || Application.get_env(:fast_ts, :route_dir)
+  end
+
+  # List route files in route_dir.
+  # Default to config/routes.exs if no route_dir provided
+  defp list_route_files(nil) do
+    Logger.warning "No fast_ts route_dir configured: Using route file 'config/route.exs'"
+    ["config/route.exs"]
+  end
+  defp list_route_files(route_dir) do
+    File.ls!(route_dir)
+    |> Enum.filter(fn file -> Path.extname(file) == ".exs" end)
+    |> Enum.map(fn file -> Path.join(route_dir, file) end)
+  end
+
+  # Display warning if no route modules provided, and fallback to a sensible default
+  defp check_route_files([]) do
+    Logger.error "No .exs file in route_dir"
+    # TODO register a default dumb pipeline that output everything to logs
+    []
+  end
+  defp check_route_files(exs_files) do
+    exs_files
+  end
+
+  # Compile all module files (.exs)
+  defp load_route_files(exs_files) do
+    exs_files
+    |> Enum.map(&Code.load_file/1)
+  end
+
+end

--- a/lib/fast_ts/router/modules_registry.ex
+++ b/lib/fast_ts/router/modules_registry.ex
@@ -1,4 +1,10 @@
 defmodule FastTS.Router.ModulesRegistry do
+  @moduledoc """
+  Router modules Registry
+
+  Simple Agent that keeps track of the Registered Router modules
+  """
+
   @doc """
   Router agent: Keeps and serves the list of router modules.
   """
@@ -9,7 +15,7 @@ defmodule FastTS.Router.ModulesRegistry do
   @doc """
   Retrieve the list of register router modules.
   """
-  def get do
+  def list do
     Agent.get(__MODULE__, fn modules -> modules end)
   end
 
@@ -17,7 +23,7 @@ defmodule FastTS.Router.ModulesRegistry do
   Register a module as FastTS router.
   """
   def register(module) do
-    Agent.update(__MODULE__, fn modules -> [module|modules] end)
+    Agent.update(__MODULE__, fn modules -> modules ++ [module] end)
   end
 
   def stop do

--- a/lib/fast_ts/router/modules_registry.ex
+++ b/lib/fast_ts/router/modules_registry.ex
@@ -1,5 +1,4 @@
-# TODO Module should be renamed registry
-defmodule FastTS.Router.Modules do
+defmodule FastTS.Router.ModulesRegistry do
   @doc """
   Router agent: Keeps and serves the list of router modules.
   """

--- a/lib/fast_ts/server.ex
+++ b/lib/fast_ts/server.ex
@@ -3,7 +3,7 @@ defmodule FastTS.Server do
   require Logger
   
   @doc """
-  Starts accepting connections on the give `port`.
+  Starts accepting connections on the given `port`.
   """
   @spec accept(port :: integer) :: no_return
   def accept(port) do
@@ -14,13 +14,13 @@ defmodule FastTS.Server do
 
   defp loop_acceptor(socket) do
     {:ok, client} = :gen_tcp.accept(socket)
+    Logger.debug "Client connected"
     pid = spawn(fn -> serve(client) end)
     :ok = :gen_tcp.controlling_process(client, pid)
     loop_acceptor(socket)
   end
 
   def serve(socket) do
-    Logger.debug "Client connected"
     result = socket |> read_message |> send_response
     case result do
       :stop ->
@@ -61,7 +61,7 @@ defmodule FastTS.Server do
   defp stream_event(event) do
     # TODO:
     # - Catch to avoid crash and report errors
-    FastTS.Router.ModulesRegistry.get
+    FastTS.Router.Modules.list
     |> Enum.each(fn(module) -> apply(module, :stream, [event]) end)
   end
 

--- a/lib/fast_ts/server.ex
+++ b/lib/fast_ts/server.ex
@@ -61,7 +61,7 @@ defmodule FastTS.Server do
   defp stream_event(event) do
     # TODO:
     # - Catch to avoid crash and report errors
-    FastTS.Router.Modules.get
+    FastTS.Router.ModulesRegistry.get
     |> Enum.each(fn(module) -> apply(module, :stream, [event]) end)
   end
 

--- a/lib/fast_ts/stream/pipelines_supervisor.ex
+++ b/lib/fast_ts/stream/pipelines_supervisor.ex
@@ -1,0 +1,43 @@
+defmodule FastTS.Stream.Pipelines.Supervisor do
+  use Supervisor
+
+  alias FastTS.Stream
+
+  @moduledoc """
+  Pipelines Supervisor
+
+  Used to start dynamically and monitor the pipelines.
+  """
+
+  def start_link() do
+    Supervisor.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  @doc """
+  Dynamically start a pipeline process in the supervisor
+
+  ## Parameters
+
+  * `name`: Name of the pipeline, an atom built from the description of the pipeline (See FastTS.Router.pipeline)
+  * `pipeline`: List of the pipeline instructions
+  """
+  def start_pipeline(name, pipeline) do
+    Supervisor.start_child(__MODULE__, [name, pipeline])
+  end
+
+  def init(:ok) do
+    # Starts the supervisor using simple_one_for_one strategy:
+    # At init, no workers are started. Worker are expected to be started
+    # dynamically using `start_pipeline`
+    children_specs
+    |> supervise(strategy: :simple_one_for_one)
+  end
+
+  defp children_specs do
+    [
+      # Template of Pipeline Worker, uesd by simple_one_for_one strategy
+      # It starts a FastTS.Stream.Pipeline process
+      worker(Stream.Pipeline, [], restart: :permanent)
+    ]
+  end
+end

--- a/lib/fast_ts/supervisor.ex
+++ b/lib/fast_ts/supervisor.ex
@@ -2,75 +2,80 @@ defmodule FastTS.Supervisor do
   use Supervisor
 
   require Logger
-  require File
-  require Path
+
+  @moduledoc """
+  FastTS main supervisor
+
+  This Supervisor is responsible for starting and supervising the main components
+  of the application:
+
+  * Pipeline Runtime Engine (Pipeline Supervisor)
+  * Router Modules 
+  * Riemann Server
+
+  It also implements the bridging mechanism between Router Modules (provided by the End User)
+  and the Pipeline Engine.
+  
+  In particular, it:
+
+  * Ensures that the Pipeline Engine (Pipeline Supervisor) is started before the Router Modules loading
+  * Provides an API (`start_pipeline!`) for starting Pipeline processes dynamically in the Pipeline Engine
+
+  ## Supervision tree overview:
+
+  FastTS.Supervisor: FastTS main application supervisor
+   |
+   |- FastTS.Stream.Pipelines.Supervisor: Pipelines supervisor
+   |   |
+   |   |- FastTS.Stream.Pipeline: Pipeline process (started dynamically)
+   |   |
+   |   |- ... 
+   |
+   |- FastTS.Router.Modules: Supervisor for Router Modules manager
+   |   |
+   |   |- FastTS.Router.ModulesRegistry: Registry of Router Modules
+   |   |
+   |   |- FastTS.Router.ModulesLoader: Worker process that loads Router Modules
+   |
+   |- FastTS.Server: Tcp Server that accepts Riemann messages
+  """
 
   def start_link do
-    set_routes
     Supervisor.start_link(__MODULE__, [], name: __MODULE__)
   end
 
   def init([]) do
-    # TODO: We generate a spec id based on index, but pipeline id
-    # should probably be generated when compiling the router
-    modules = FastTS.Router.ModulesRegistry.get |> Enum.reduce([], fn(module, acc) ->
-      apply(module, :streams, []) ++ acc
-    end)
-
-    streams = Enum.map(Enum.with_index(modules),
-      fn({{name, pipeline}, index}) ->
-        worker(FastTS.Stream.Pipeline, [name, pipeline], id: index ) end)
-    children = streams ++
-      [
-        # TODO: Make port configurable
-        worker(Task, [FastTS.Server, :accept, [5555]])
-      ]
-    supervise(children, strategy: :one_for_one)
+    children_specs
+    |> supervise(strategy: :one_for_one)
   end
 
-  # TODO set_routes should be part of the pipeline supervision process
-  # -> Or maybe not, as of today, pipeline steps are linked process, the whole pipeline is restarted in case of crash, which is what we want
-  defp set_routes do
-    FastTS.Router.ModulesRegistry.start_link()
-    get_route_files |> Enum.map(fn(file) -> Code.load_file file end)
-  end
-  
-  defp get_route_files do
-    case get_route_dir do
-      nil ->
-        Logger.warning "No fast_ts route_dir configured: Using route file 'config/route.exs'"
-        ["config/route.exs"]
-      route_dir ->
-        {:ok, files} = File.ls(route_dir)
-        exs_files = Enum.reduce(files, [],
-          fn(file, acc) ->
-            cond do
-              Path.extname(file) == ".exs" ->
-                [Path.join(route_dir, file)|acc]
-              true ->
-                acc
-            end
-          end)
-        case exs_files do
-          [] ->
-            Logger.error "No .exs file in route_dir"
-            # TODO register a default dumb pipeline that output everything to logs
-            []
-          _ ->
-            exs_files
-        end
-    end
+  @doc """
+  Start a supervised pipeline process
+
+  ## Parameters
+
+  * `name`: Name of the pipeline, an atom built from the description of the pipeline (See FastTS.Router.pipeline)
+  * `pipeline`: List of the pipeline instructions
+  """
+  def start_pipeline!(name, pipeline) do
+    {:ok, _pid} = FastTS.Stream.Pipelines.Supervisor.start_pipeline(name, pipeline)
+    Logger.debug "pipeline #{name} started"
   end
 
-  # First try to read route dir from FTS_ROUTE_DIR environment
-  # variable, then try value from config file
-  defp get_route_dir do
-    env_route_dir = System.get_env("FTS_ROUTE_DIR")
-    case env_route_dir do
-      nil ->
-        Application.get_env(:fast_ts, :route_dir)
-      _ ->
-        env_route_dir
-    end
+  defp children_specs do
+    [
+      # Pipelines supervisor:
+      # Responsible for starting and supervise Pipeline processes dynamically
+      supervisor(FastTS.Stream.Pipelines.Supervisor, []),
+      # Router modules manager:
+      # Responsible for loading and starting Router Modules
+      worker(FastTS.Router.Modules, []),
+      # Riemann Message Server:
+      # Responsible for accepting input Riemann messages and forwarding
+      # events to the pipelines
+      # TODO: Make port configurable
+      worker(Task, [FastTS.Server, :accept, [5555]])
+    ]
   end
+
 end

--- a/lib/fast_ts/supervisor.ex
+++ b/lib/fast_ts/supervisor.ex
@@ -13,7 +13,7 @@ defmodule FastTS.Supervisor do
   def init([]) do
     # TODO: We generate a spec id based on index, but pipeline id
     # should probably be generated when compiling the router
-    modules = FastTS.Router.Modules.get |> Enum.reduce([], fn(module, acc) ->
+    modules = FastTS.Router.ModulesRegistry.get |> Enum.reduce([], fn(module, acc) ->
       apply(module, :streams, []) ++ acc
     end)
 
@@ -31,7 +31,7 @@ defmodule FastTS.Supervisor do
   # TODO set_routes should be part of the pipeline supervision process
   # -> Or maybe not, as of today, pipeline steps are linked process, the whole pipeline is restarted in case of crash, which is what we want
   defp set_routes do
-    FastTS.Router.Modules.start_link()
+    FastTS.Router.ModulesRegistry.start_link()
     get_route_files |> Enum.map(fn(file) -> Code.load_file file end)
   end
   


### PR DESCRIPTION
This PR refactors of the supervision tree initialization logic, in order to:
- Limit the Main application Supervisor responsibility to high level application structure
- Move the module registry in a dedicated module `FastTS.Router.ModulesRegistry`
- Move Router Module initialization and loading to  `FastTS.Router.Modules` module
- Provide a separation of concerns between Pipeline setup and runtime
